### PR TITLE
Feature/transactions currency convert

### DIFF
--- a/Managers/AccountManager.cs
+++ b/Managers/AccountManager.cs
@@ -107,21 +107,21 @@ namespace bank_app.Managers
 
         //Methods for Deposit and Withdraw to update Balance
         /// </summary>
-        public static void Deposit(Guid accountId, Transaction transaction)
+        public static void Deposit(Guid accountId, Transaction transaction, decimal amount)
         {
             transaction.TransactionType = TransactionType.Deposit;
             var account = GetOrThrow(accountId);
-            account.ApplyTransaction(transaction);
+            account.ApplyTransaction(transaction, amount);
         }
 
         /// <summary>
         /// Deducts balance from account using unique identifier and data from transaction.
         /// </summary>
-        public static void Withdraw(Guid accountId, Transaction transaction)
+        public static void Withdraw(Guid accountId, Transaction transaction, decimal amount)
         {
             transaction.TransactionType = TransactionType.Withdrawal;
             var account = GetOrThrow(accountId);
-            account.ApplyTransaction(transaction);
+            account.ApplyTransaction(transaction, amount);
         }
 
         /// <summary>

--- a/Managers/AccountManager.cs
+++ b/Managers/AccountManager.cs
@@ -105,8 +105,10 @@ namespace bank_app.Managers
             return null;
         }
 
-        //Methods for Deposit and Withdraw to update Balance
+        /// <summary>
+        /// Adds balance to an account using data from a transaction object. 
         /// </summary>
+        /// <param name="accountId">The unique identifier (Guid) for an Account object</param>
         public static void Deposit(Guid accountId, Transaction transaction, decimal amount)
         {
             transaction.TransactionType = TransactionType.Deposit;
@@ -117,6 +119,7 @@ namespace bank_app.Managers
         /// <summary>
         /// Deducts balance from account using unique identifier and data from transaction.
         /// </summary>
+        /// /// /// <param name="accountId">The unique identifier (Guid) for an Account object</param>
         public static void Withdraw(Guid accountId, Transaction transaction, decimal amount)
         {
             transaction.TransactionType = TransactionType.Withdrawal;

--- a/Managers/LoanManager.cs
+++ b/Managers/LoanManager.cs
@@ -30,7 +30,7 @@ namespace bank_app.Managers
             _loans.Add(loan);
 
             var transaction = CreateLoanTransaction(loanAccount, principal);
-            loanAccount.ApplyTransaction(transaction);
+            loanAccount.ApplyTransaction(transaction, principal);
 
             return loan;
 

--- a/Managers/TransactionManager.cs
+++ b/Managers/TransactionManager.cs
@@ -79,6 +79,7 @@ namespace bank_app.Managers
                         transactionAmount = CurrencyExchange.ExchangeFromSek(transactionAmount, receiverAccount.AccountCurrency);
                     }
 
+                    //Performs the deposit to receivers account in receiver accounts local currency which will be saved in "transactionAmount". 
                     AccountManager.Deposit(transaction.ReceiverId, transaction, transactionAmount);
                     transaction.Status = TransferStatus.Completed;
                 }

--- a/Managers/TransactionManager.cs
+++ b/Managers/TransactionManager.cs
@@ -55,15 +55,31 @@ namespace bank_app.Managers
                 {
                     //Checks if sender has enough funds in account to perform transaction
                     var senderAccount = AccountManager.GetOrThrow(transaction.SenderId);
+                    var receiverAccount = AccountManager.GetOrThrow(transaction.ReceiverId);
                     if (senderAccount.Balance < transaction.TransferAmount)
                     {
                         transaction.Status = TransferStatus.Failed;
                         continue;
                     }
 
-                    //Performs the transaction and marks it as completed
-                    AccountManager.Withdraw(transaction.SenderId, transaction);
-                    AccountManager.Deposit(transaction.ReceiverId, transaction);
+                    //First the method performs a withdrawal of the sender accounts local currency
+                    AccountManager.Withdraw(transaction.SenderId, transaction, transaction.TransferAmount);
+
+                    decimal transactionAmount = transaction.TransferAmount;
+
+                    //Checks to see if sender account is in other currency than base currency SEK and in that case exchanges it to SEK and saves it to transactionAmount. 
+                    if (senderAccount.AccountCurrency != Currency.SEK)
+                    {
+                        transactionAmount = CurrencyExchange.ExchangeToSek(transactionAmount, senderAccount.AccountCurrency);
+                    }
+
+                    //Checks to see if receiver account is in other currency than base currency SEK and in that case exchanges it from SEK to accounts local currency. 
+                    if (receiverAccount.AccountCurrency != Currency.SEK)
+                    {
+                        transactionAmount = CurrencyExchange.ExchangeFromSek(transactionAmount, receiverAccount.AccountCurrency);
+                    }
+
+                    AccountManager.Deposit(transaction.ReceiverId, transaction, transactionAmount);
                     transaction.Status = TransferStatus.Completed;
                 }
 

--- a/Models/Accounts/Account.cs
+++ b/Models/Accounts/Account.cs
@@ -22,7 +22,7 @@ namespace bank_app.Models.Accounts
             Balance = balance < 0 ? 0 : balance;
             OwnerId = ownerId;
         }
-        internal void ApplyTransaction(Transaction transaction)
+        internal void ApplyTransaction(Transaction transaction, decimal amount)
         {
             if (!CanApply(transaction))
             {
@@ -32,10 +32,10 @@ namespace bank_app.Models.Accounts
             switch (transaction.TransactionType)
             {
                 case TransactionType.Deposit:
-                    Balance += transaction.TransferAmount;
+                    Balance += amount;
                     break;
                 case TransactionType.Withdrawal:
-                    Balance -= transaction.TransferAmount;
+                    Balance -= amount;
                     break;
                 default:
                     Console.WriteLine("This transaction type is not an option");

--- a/Models/Accounts/Account.cs
+++ b/Models/Accounts/Account.cs
@@ -22,6 +22,9 @@ namespace bank_app.Models.Accounts
             Balance = balance < 0 ? 0 : balance;
             OwnerId = ownerId;
         }
+        /// <summary>
+        /// Method that adds or subtracts balance in accounts local currency, while also saving all transactions made into a List. 
+        /// </summary>
         internal void ApplyTransaction(Transaction transaction, decimal amount)
         {
             if (!CanApply(transaction))

--- a/Models/Accounts/SavingsAccount.cs
+++ b/Models/Accounts/SavingsAccount.cs
@@ -95,7 +95,7 @@ namespace bank_app.Models.Accounts
                 Status = TransferStatus.Completed
             };
 
-            ApplyTransaction(interestTransaction);
+            ApplyTransaction(interestTransaction, interest);
 
             LastInterestDate = LastInterestDate.AddDays(days);
         }

--- a/Models/Currency.cs
+++ b/Models/Currency.cs
@@ -8,6 +8,7 @@ namespace bank_app.Models
 {
     public enum Currency
     {
+        SEK,  //Swedish krona (BASE CURRENCY)
         USD,  //Dollar
         EUR,  //Euro
         GBP,  //Pound Sterling
@@ -16,7 +17,6 @@ namespace bank_app.Models
         CAD,  //Canadian Dollar
         CHF,  //Swiss Franc
         CNY,  //Chinese Yuan
-        SEK,  //Swedish Krona
         NZD,  //New Zealand Dollar
         SLC   // Slava Coin
     }

--- a/Models/CurrencyExchange.cs
+++ b/Models/CurrencyExchange.cs
@@ -24,5 +24,15 @@ namespace bank_app.Models
             {Currency.NZD, 0.18m },
             {Currency.SLC, 0.000004m }
         };
+        public static decimal ExchangeToSek(decimal amount, Currency currencyFrom, Currency sek = Currency.SEK)
+        {
+            decimal exchangeRate = _ratesToSEK[currencyFrom];
+            return amount / exchangeRate;
+        }
+        public static decimal ExchangeFromSek(decimal amount, Currency currencyTo, Currency sek = Currency.SEK)
+        {
+            decimal exchangeRate = _ratesToSEK[currencyTo];
+            return amount * exchangeRate;
+        }
     }
 }

--- a/Models/CurrencyExchange.cs
+++ b/Models/CurrencyExchange.cs
@@ -34,5 +34,42 @@ namespace bank_app.Models
             decimal exchangeRate = _ratesToSEK[currencyTo];
             return amount * exchangeRate;
         }
+
+        /// <summary>
+        /// Updates the exchange rate of a chosen currency in the currency list based on the base currency SEK.
+        /// This method is meant to be used by Admin user to update current exchange rates. 
+        /// </summary>
+        /// <param name="currency">The chosen currency to update exchange rate of</param>
+        /// <param name="rateToSek">The chosen exchange rate of that currency based on base rate (SEK)</param>
+        public static void UpdateRate(Currency currency, decimal rateToSek)
+        {
+            if (currency == Currency.SEK)
+            {
+                throw new ArgumentException("Cannot change the base rate (SEK)");
+            }
+
+            if (rateToSek <= 0)
+            {
+                throw new ArgumentException("Exchange rate must be more than 0");
+            }
+
+            _ratesToSEK[currency] = rateToSek;
+        }
+
+        /// <summary>
+        /// Method to be used by UI to display all current rates based on the base rate.
+        /// </summary>
+        public static Dictionary<Currency, decimal> GetAllRates()
+        {
+            return new Dictionary<Currency, decimal>(_ratesToSEK);
+        }
+
+        /// <summary>
+        /// Method to be used by UI to display current rate of a chosen currency based on the base rate. 
+        /// </summary>
+        public static decimal GetRate(Currency currency)
+        {
+            return _ratesToSEK[currency];
+        }
     }
 }

--- a/Models/CurrencyExchange.cs
+++ b/Models/CurrencyExchange.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using static System.Runtime.InteropServices.JavaScript.JSType;
+
+namespace bank_app.Models
+{
+    public class CurrencyExchange
+    {
+        //Exchange rates relative to our base currency (SEK)
+        private static Dictionary<Currency, decimal> _ratesToSEK = new Dictionary<Currency, decimal>
+        {
+            {Currency.SEK, 1.00m },
+            {Currency.USD, 0.11m },
+            {Currency.EUR, 0.09m },
+            {Currency.GBP, 0.08m },
+            {Currency.JPY, 16.26m },
+            {Currency.AUD, 0.16m },
+            {Currency.CAD, 0.15m },
+            {Currency.CHF, 0.09m },
+            {Currency.CNY, 0.76m },
+            {Currency.NZD, 0.18m },
+            {Currency.SLC, 0.000004m }
+        };
+    }
+}

--- a/Models/CurrencyExchange.cs
+++ b/Models/CurrencyExchange.cs
@@ -41,19 +41,22 @@ namespace bank_app.Models
         /// </summary>
         /// <param name="currency">The chosen currency to update exchange rate of</param>
         /// <param name="rateToSek">The chosen exchange rate of that currency based on base rate (SEK)</param>
-        public static void UpdateRate(Currency currency, decimal rateToSek)
+        public static bool UpdateRate(Currency currency, decimal rateToSek)
         {
             if (currency == Currency.SEK)
             {
+                return false;
                 throw new ArgumentException("Cannot change the base rate (SEK)");
             }
 
             if (rateToSek <= 0)
             {
+                return false;
                 throw new ArgumentException("Exchange rate must be more than 0");
             }
 
             _ratesToSEK[currency] = rateToSek;
+            return true;
         }
 
         /// <summary>

--- a/Program.cs
+++ b/Program.cs
@@ -1,5 +1,6 @@
 ﻿using bank_app.UI;
 using bank_app.Managers;
+using bank_app.Utility;
 
 internal class Program
 {


### PR DESCRIPTION

### What has been done:

- Added feature to transaction and account logic that makes it possible to convert between the sender accounts local currency, to the receiver accounts local currency.
- Currencies are currently stored in a CurrencyExchange.cs class, inside a dictionary. This class also performs the currency conversions.
- TransactionManager.cs now checks for the Accounts local currency, and decides if a conversion is needed or not before the amount is deposited to the receivers account.

### Future fixes:

- Admin needs to be able to edit the exchange rates inside the disctionary from the UI

### Keep in mind:

- A transaction will ALWAYS be made in the sender accounts LOCAL currency. It is not possible to choose which currency the transaction should be in.

